### PR TITLE
Revert "Bump boto3 from 1.13.11 to 1.14.7"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-boto3==1.14.7
+boto3==1.13.11
 python-lambda==11.7.1


### PR DESCRIPTION
Reverts GovWizely/lambda-steel#18

ERROR: python-lambda 11.7.1 has requirement boto3==1.4.4, but you'll have boto3 1.14.7 which is incompatible.